### PR TITLE
Make web part responsive mobile first

### DIFF
--- a/apps/webapp/src/screens/CreateLobbyScreen.tsx
+++ b/apps/webapp/src/screens/CreateLobbyScreen.tsx
@@ -120,7 +120,7 @@ export const CreateLobbyScreen: React.FC = () => {
   };
 
   return (
-    <div className="min-h-screen bg-bg-deep text-foam">
+    <div className="min-h-screen bg-bg-deep text-foam" style={{ paddingTop: 'env(safe-area-inset-top)', paddingBottom: 'env(safe-area-inset-bottom)' }}>
       {/* Header */}
       <div className="bg-steel border-b border-edge/50 px-4 py-3">
         <div className="flex items-center justify-between">

--- a/apps/webapp/src/screens/GameScreen.tsx
+++ b/apps/webapp/src/screens/GameScreen.tsx
@@ -185,7 +185,7 @@ export const GameScreen: React.FC = () => {
   }
 
   return (
-    <div className="min-h-screen bg-tg-bg p-4">
+    <div className="min-h-screen bg-tg-bg p-4" style={{ paddingTop: 'env(safe-area-inset-top)', paddingBottom: 'env(safe-area-inset-bottom)' }}>
       <div className="max-w-2xl mx-auto">
         {/* Header */}
         <div className="text-center mb-6">

--- a/apps/webapp/src/screens/LeaderboardScreen.tsx
+++ b/apps/webapp/src/screens/LeaderboardScreen.tsx
@@ -118,7 +118,7 @@ export const LeaderboardScreen: React.FC = () => {
   };
 
   return (
-    <div className="min-h-screen bg-bg-deep text-foam">
+    <div className="min-h-screen bg-bg-deep text-foam" style={{ paddingTop: 'env(safe-area-inset-top)', paddingBottom: 'env(safe-area-inset-bottom)' }}>
       {/* Header */}
       <div className="bg-steel border-b border-edge/50 px-4 py-3">
         <div className="flex items-center justify-between">

--- a/apps/webapp/src/screens/LobbyScreen.tsx
+++ b/apps/webapp/src/screens/LobbyScreen.tsx
@@ -180,7 +180,7 @@ export const LobbyScreen: React.FC = () => {
   const canStartGame = isHost && allPlayersReady;
 
   return (
-    <div className="min-h-screen bg-bg-deep text-foam">
+    <div className="min-h-screen bg-bg-deep text-foam" style={{ paddingTop: 'env(safe-area-inset-top)', paddingBottom: 'env(safe-area-inset-bottom)' }}>
       {/* Header */}
       <div className="bg-steel border-b border-edge/50 px-4 py-3">
         <div className="flex items-center justify-between">

--- a/apps/webapp/src/screens/ProfileScreen.tsx
+++ b/apps/webapp/src/screens/ProfileScreen.tsx
@@ -34,7 +34,7 @@ export const ProfileScreen: React.FC = () => {
   };
 
   return (
-    <div className="min-h-screen bg-bg-deep text-foam">
+    <div className="min-h-screen bg-bg-deep text-foam" style={{ paddingTop: 'env(safe-area-inset-top)', paddingBottom: 'env(safe-area-inset-bottom)' }}>
       {/* Header */}
       <div className="bg-steel border-b border-edge/50 px-4 py-3">
         <div className="flex items-center justify-between">

--- a/apps/webapp/src/screens/SettingsScreen.tsx
+++ b/apps/webapp/src/screens/SettingsScreen.tsx
@@ -36,7 +36,7 @@ export const SettingsScreen: React.FC = () => {
   };
 
   return (
-    <div className="min-h-screen bg-bg-deep text-foam">
+    <div className="min-h-screen bg-bg-deep text-foam" style={{ paddingTop: 'env(safe-area-inset-top)', paddingBottom: 'env(safe-area-inset-bottom)' }}>
       {/* Header */}
       <div className="bg-steel border-b border-edge/50 px-4 py-3">
         <div className="flex items-center justify-between">

--- a/apps/webapp/src/screens/SetupScreen.tsx
+++ b/apps/webapp/src/screens/SetupScreen.tsx
@@ -251,7 +251,7 @@ export const SetupScreen: React.FC = () => {
   // Рендер компонента
   return (
     // Основной контейнер с минимальной высотой экрана и темным фоном
-    <div className="min-h-screen bg-bg-deep text-foam">
+    <div className="min-h-screen bg-bg-deep text-foam" style={{ paddingTop: 'env(safe-area-inset-top)', paddingBottom: 'env(safe-area-inset-bottom)' }}>
       {/* Заголовок страницы */}
       <div className="bg-steel border-b border-edge/50 px-4 py-3">
         <div className="flex items-center justify-between">

--- a/packages/ui/src/components/Board.tsx
+++ b/packages/ui/src/components/Board.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Cell, CellState } from './Cell';
-import { BoardSize, sizeConfig, gapPx, coordinates, BOARD_SIZE } from '../utils/boardConfig';
+import { BoardSize, adaptiveSizeConfig, gapPx, coordinates, BOARD_SIZE } from '../utils/boardConfig';
 
 interface BoardProps {
   size?: BoardSize;
@@ -23,8 +23,7 @@ export const Board: React.FC<BoardProps> = React.memo(({
   showCoordinates = true,
   isOpponent = false,
 }) => {
-  const config = sizeConfig[size];
-  const { cellPx, padPx } = config;
+  const { cellPx, padPx } = adaptiveSizeConfig[size];
 
   // Валидация размера поля в dev-режиме
   if (process.env.NODE_ENV !== 'production') {
@@ -47,12 +46,12 @@ export const Board: React.FC<BoardProps> = React.memo(({
 
   return (
     <div 
-      className={`relative ${className}`}
+      className={`relative overflow-x-auto max-w-full ${className}`}
       style={{
-        // CSS-vars — единый источник размеров
-        ['--cell' as any]: `${cellPx}px`,
+        // CSS-vars — единый источник размеров с адаптивными значениями
+        ['--cell' as any]: cellPx,
         ['--gap' as any]: `${gapPx}px`,
-        ['--pad' as any]: `${padPx}px`,
+        ['--pad' as any]: padPx,
       }}
       onContextMenu={(e) => e.preventDefault()}
     >

--- a/packages/ui/src/components/Modal.tsx
+++ b/packages/ui/src/components/Modal.tsx
@@ -70,13 +70,14 @@ export const Modal: React.FC<ModalProps> = ({
           {/* Modal */}
           <div
             className={`
-              relative w-full max-w-md bg-bg-graphite rounded-modal
-              ring-1 ring-edge border border-edge/50
+              relative w-full max-w-md max-h-[calc(100vh-2rem)] bg-bg-graphite rounded-modal
+              ring-1 ring-edge border border-edge/50 overflow-y-auto
               ${className}
             `}
+            style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
           >
             {/* Заголовок */}
-            <div className="flex items-center justify-between p-6 pb-4 border-b border-edge/50">
+            <div className="sticky top-0 bg-bg-graphite z-10 flex items-center justify-between p-6 pb-4 border-b border-edge/50" style={{ paddingTop: 'env(safe-area-inset-top)' }}>
               <h2 className="font-heading font-semibold text-h3 text-foam">
                 {title}
               </h2>


### PR DESCRIPTION
Implement mobile-first responsiveness by adapting UI components and screen layouts for various mobile viewports and safe-area insets.

The changes ensure the game board scales correctly, modals are scrollable and fit within the screen, and all main screens account for device-specific safe-area cutouts, providing a better user experience on mobile devices.

---
<a href="https://cursor.com/background-agent?bcId=bc-1c01f814-73f6-419c-bc1e-52c00275bec7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1c01f814-73f6-419c-bc1e-52c00275bec7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

